### PR TITLE
Select best stream /w 60fps supported

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -161,16 +161,16 @@ def getStreamVCO(date, game, feed):
 					continue
 				else:
 					bw, width_s, height_s = stream_meta.groups()
-					fps = 30
+					fps_s = '30'
 
 			else:
-				bw, width_s, height_s, fps = stream_meta.groups()
+				bw, width_s, height_s, fps_s = stream_meta.groups()
 
 			res_url = real_url.rsplit('/', 1)[0] + "/" + url_end
 			media_object = MediaObject(
 					protocol = 'hls',
 					video_codec = VideoCodec.H264,
-					video_frame_rate = str(fps),
+					video_frame_rate = fps_s,
 					audio_codec = AudioCodec.AAC,
 					video_resolution = height_s,
 					audio_channels = 2,
@@ -180,11 +180,11 @@ def getStreamVCO(date, game, feed):
 					]
 				)
 
-			if int(height_s) < best_height or float(fps) < best_fps:
+			if int(height_s) < best_height or float(fps_s) < best_fps:
 				objects.append(media_object)
 			else:
 				best_height = int(height_s)
-				best_fps = float(fps)
+				best_fps = float(fps_s)
 				objects.insert(0, media_object)
 
 		STREAM_CACHE[game.game_id][feed.mediaId] = objects

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -138,9 +138,13 @@ def getStreamVCO(date, game, feed):
 		except:
 			return []
 
+		fps_info_pattern = re.compile('EXT-X-STREAM-INF:BANDWIDTH=(\d+),RESOLUTION=(\d+)x(\d+),FRAME-RATE=(\d+\.\d+),CODECS=".+"')
 		info_pattern = re.compile('EXT-X-STREAM-INF:BANDWIDTH=(\d+),RESOLUTION=(\d+)x(\d+),CODECS=".+"')
 		streams = HTTP.Request(real_url).content.split("#")
 		objects = []
+
+		best_fps = 0.0
+		best_height = 0
 
 		for stream in streams:
 			try:
@@ -149,16 +153,30 @@ def getStreamVCO(date, game, feed):
 				Log(stream)
 				continue
 			info, url_end = stream.splitlines()
-			stream_meta = info_pattern.search(info)
+
+			stream_meta = fps_info_pattern.search(info)
 			if stream_meta == None:
+				stream_meta = info_pattern.search(info)
+				if stream_meta == None:
+					continue
+				else:
+					bw, width_s, height_s = stream_meta.groups()
+					fps = 30.0
+
+			else:
+				bw, width_s, height_s, fps = stream_meta.groups()
+
+			if int(height_s) < best_height or float(fps) < best_fps:
 				continue
-			bw, width_s, height_s = stream_meta.groups()
+
+			best_height = int(height_s)
+			best_fps = float(fps)
+
 			res_url = real_url.rsplit('/', 1)[0] + "/" + url_end
-			objects.append(
-				MediaObject(
+			best_object = MediaObject(
 					protocol = 'hls',
 					video_codec = VideoCodec.H264,
-					video_frame_rate = 30,
+					video_frame_rate = fps,
 					audio_codec = AudioCodec.AAC,
 					video_resolution = height_s,
 					audio_channels = 2,
@@ -167,8 +185,8 @@ def getStreamVCO(date, game, feed):
 						PartObject(key = HTTPLiveStreamURL(Callback(PlayStream, url=res_url)))
 					]
 				)
-			)
 
+		objects.append(best_object)
 		STREAM_CACHE[game.game_id][feed.mediaId] = objects
 		return objects
 

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -143,7 +143,7 @@ def getStreamVCO(date, game, feed):
 		streams = HTTP.Request(real_url).content.split("#")
 		objects = []
 
-		best_fps = 0.0
+		best_fps = 0
 		best_height = 0
 
 		for stream in streams:
@@ -161,22 +161,16 @@ def getStreamVCO(date, game, feed):
 					continue
 				else:
 					bw, width_s, height_s = stream_meta.groups()
-					fps = 30.0
+					fps = 30
 
 			else:
 				bw, width_s, height_s, fps = stream_meta.groups()
 
-			if int(height_s) < best_height or float(fps) < best_fps:
-				continue
-
-			best_height = int(height_s)
-			best_fps = float(fps)
-
 			res_url = real_url.rsplit('/', 1)[0] + "/" + url_end
-			best_object = MediaObject(
+			media_object = MediaObject(
 					protocol = 'hls',
 					video_codec = VideoCodec.H264,
-					video_frame_rate = fps,
+					video_frame_rate = str(fps),
 					audio_codec = AudioCodec.AAC,
 					video_resolution = height_s,
 					audio_channels = 2,
@@ -186,7 +180,13 @@ def getStreamVCO(date, game, feed):
 					]
 				)
 
-		objects.append(best_object)
+			if int(height_s) < best_height or float(fps) < best_fps:
+				objects.append(media_object)
+			else:
+				best_height = int(height_s)
+				best_fps = float(fps)
+				objects.insert(0, media_object)
+
 		STREAM_CACHE[game.game_id][feed.mediaId] = objects
 		return objects
 


### PR DESCRIPTION
This covers two issues I ran into.

Issue 1. The pattern match ignored streams with the frame rate specified which skipped the 59.94 fps streams.

Issue 2. Plex seemed to always consider the first stream added to the objects array as the original source even if it was of lower resolution preventing the use of a higher quality stream.